### PR TITLE
Example: new customization options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,27 @@
-import { JSONDive } from "@jsondive/viewer"
+import { JSONDive, type JSONDiveOptions } from "@jsondive/viewer"
 
 import "@jsondive/viewer/dist/root.css"
+import { useMemo } from "react"
+import * as lucideReact from "lucide-react"
 
 function App() {
+	const options = useMemo(
+		(): JSONDiveOptions => ({
+			onValueMagnified(args) {
+				console.log(`Value magnified: ${args.value}`)
+			},
+
+			icons: {
+				magnify: lucideReact.Sun,
+				image: lucideReact.Sailboat,
+			},
+		}),
+		[]
+	)
+
 	return (
 		<div style={{ width: 400, height: 400 }}>
-			<JSONDive data={jsonDoc} />
+			<JSONDive data={jsonDoc} options={options} />
 		</div>
 	)
 }

--- a/src/index.css
+++ b/src/index.css
@@ -8,3 +8,9 @@
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
+
+.json-dive-viewer-instance {
+	--json-dive-color-badge-background: oklch(
+		0.902 0.063 306.703
+	); /* purple-200 */
+}


### PR DESCRIPTION
This PR customizes JSON dive to change the background color for icons as well as the icons themselves, plus overriding onValueMagnified.

<img width="406" height="404" alt="image" src="https://github.com/user-attachments/assets/48207fa0-df45-469a-9227-91c7a64ec43b" />
